### PR TITLE
gradlew is recommended over the standard gradle

### DIFF
--- a/src/taskProviderGradle.ts
+++ b/src/taskProviderGradle.ts
@@ -199,9 +199,9 @@ function createGradleTask(target: string, cmd: string, folder: WorkspaceFolder, 
 {
     function getCommand(folder: WorkspaceFolder, cmd: string): string
     {
-        let gradle = "gradle";
+        let gradle = "gradlew";
         if (process.platform === "win32") {
-            gradle = "gradle.bat";
+            gradle = "gradlew.bat";
         }
         if (workspace.getConfiguration("taskExplorer").get("pathToGradle")) {
             gradle = workspace.getConfiguration("taskExplorer").get("pathToGradle");


### PR DESCRIPTION
In an overwhelming number of projects the vanilla gradle command is only used to install the gradle wrapper. All project tasks use the gradle wrapper command, gradlew for actual builds.