### PR TITLE
Create parseTargetLine with support for Makefile aliases

### DIFF
--- a/src/taskProviderMake.ts
+++ b/src/taskProviderMake.ts
@@ -190,6 +190,15 @@ function isNormalTarget(target: string): boolean
     return true;
 }
 
+function parseTargetLine(line: string)
+{
+  const tgtAliases = line.split(":")[0].trim().split(" ");
+  const tgtName = tgtAliases[tgtAliases.length - 1];
+
+  const dependsName = line.substring(line.indexOf(":") + 1).trim();
+
+  return { tgtName, dependsName };
+}
 
 async function findTargets(fsPath: string): Promise<StringMap>
 {
@@ -214,8 +223,8 @@ async function findTargets(fsPath: string): Promise<StringMap>
         if (line.length > 0 && !line.startsWith("\t") && !line.startsWith(" ") &&
             !line.startsWith("#") && !line.startsWith("$") && line.indexOf(":") > 0)
         {
-            const tgtName = line.substring(0, line.indexOf(":")).trim();
-            const dependsName = line.substring(line.indexOf(":") + 1).trim();
+            const { tgtName, dependsName } = parseTargetLine(line);
+
             //
             // Don't include object targets
             //

--- a/src/taskProviderMake.ts
+++ b/src/taskProviderMake.ts
@@ -192,8 +192,8 @@ function isNormalTarget(target: string): boolean
 
 function parseTargetLine(line: string)
 {
-  const tgtAliases = line.split(":")[0].trim().split(" ");
-  const tgtName = tgtAliases[tgtAliases.length - 1];
+  const tgtNames = line.split(":")[0].trim();
+  const tgtName = tgtNames.split(" ").slice(-1);
 
   const dependsName = line.substring(line.indexOf(":") + 1).trim();
 

--- a/src/taskProviderMake.ts
+++ b/src/taskProviderMake.ts
@@ -190,14 +190,14 @@ function isNormalTarget(target: string): boolean
     return true;
 }
 
-function parseTargetLine(line: string)
+function parseTargetLine(line)
 {
-  const tgtNames = line.split(":")[0].trim();
-  const tgtName = tgtNames.split(" ").slice(-1);
+    const tgtNames = line.split(":")[0].trim();
+    const tgtName = tgtNames.split(" ").slice(-1)[0];
 
-  const dependsName = line.substring(line.indexOf(":") + 1).trim();
+    const dependsName = line.substring(line.indexOf(":") + 1).trim();
 
-  return { tgtName, dependsName };
+    return { tgtName, dependsName };
 }
 
 async function findTargets(fsPath: string): Promise<StringMap>


### PR DESCRIPTION
## Problem

I often write a Makefile like

```
s serve:
  # ...
```

And the extension turns that into `s serve` in the panel. And when run it goes to:

```sh
make s serve
```

Which then results in an error target not found.

## Solution

So my change is to add support for aliases, so that it becomes `serve` and runs as 

```sh
make serve
```

## Testing

```js
> // Standard
> parseTargetLine('foo:')
{ tgtName: 'foo', dependsName: '' }

// Ignore the f alias which occurs before foo
> parseTargetLine('f foo:') 
{ tgtName: 'foo', dependsName: '' }

> // Backward compatibility, to keep the depends on
> parseTargetLine('foo: bar baz')
{ tgtName: 'foo', dependsName: 'bar baz' }

> parseTargetLine('f foo: bar baz')
{ tgtName: 'foo', dependsName: 'bar baz' }
```

With space padding.

```js
> parseTargetLine('foo :')
{ tgtName: 'foo', dependsName: '' } 

> parseTargetLine('f foo :')
{ tgtName: 'foo', dependsName: '' } 

> parseTargetLine('f foo : bar')
{ tgtName: 'foo', dependsName: 'bar' }
```