### PR TITLE
remove last task(s) that is over numLastTasks when saveRunTask

### DIFF
--- a/src/taskTree.ts
+++ b/src/taskTree.ts
@@ -586,7 +586,7 @@ export class TaskTreeDataProvider implements TreeDataProvider<TreeItem>
         {
             util.removeFromArray(lastTasks, taskId);
         }
-        if (lastTasks.length >= configuration.get<number>("numLastTasks"))
+        while (lastTasks.length >= configuration.get<number>("numLastTasks"))
         {
             lastTasks.shift();
         }


### PR DESCRIPTION
When change `taskExplorer.numLastTasks` to a smaller value, the last tasks should be cut down as well